### PR TITLE
Bump to 1.18

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Have Release Engineering added as a reviewer to any packaging PR
+* @daos-stack/release-engineering

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,4 +40,4 @@
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
 
-packageBuildingPipelineDAOS(['distros': ['centos7', 'centos8', 'leap15']])
+packageBuildingPipelineDAOS(['distros': ['el7', 'el8', 'leap15']])

--- a/go.spec
+++ b/go.spec
@@ -2,10 +2,12 @@
 %define debug_package %{nil}
 %undefine _missing_build_ids_terminate_build
 
-%define _go_rel 1.17
-%define _go_patch 8
+%define _go_rel 1.18
+%define _go_patch 0
 
 %if (0%{?suse_version} > 0)
+# Sigh. SuSE.
+Epoch:		1
 Name:		go%{_go_rel}
 %else
 %if (0%{?rhel} >= 7)
@@ -14,7 +16,11 @@ Name:		golang
 Name:		go
 %endif
 %endif
+%if (0%{?_go_patch} > 0)
 Version:	%{_go_rel}.%{_go_patch}
+%else
+Version:	%{_go_rel}
+%endif
 Release:	1.daos%{?dist}
 Summary:	The Go Programming Language
 
@@ -59,6 +65,9 @@ cp -a src %{buildroot}/%{_exec_prefix}
 %doc
 
 %changelog
+* Thu Mar 17 2022 Michael J. MacDonald <mjmac.macdonald@intel.com> - 1.18-1
+- Update to 1.18
+
 * Fri Mar 04 2022 David Quigley <david.quigley@intel.com> - 1.17.8-1
 - Bump the patch version to apply fixes for new CVEs
 

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -5,8 +5,8 @@
 #
 
 # Pull base image
-FROM fedora:35
-LABEL maintainer="daos@daos.groups.io>"
+FROM fedora:latest
+LABEL maintainer="daos@daos.groups.io"
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000
@@ -14,7 +14,7 @@ ARG UID=1000
 # Install basic tools
 RUN dnf -y install mock make \
                    rpm-build curl createrepo rpmlint redhat-lsb-core git \
-                   python-srpm-macros rpmdevtools mock-core-configs\ \<\ 37.1
+                   python-srpm-macros rpmdevtools
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build
@@ -29,5 +29,5 @@ RUN grep use_nspawn /etc/mock/site-defaults.cfg || \
     echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
 ARG CACHEBUST
-RUN dnf -y upgrade --exclude mock-core-configs && \
+RUN dnf -y upgrade && \
     dnf clean all

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -26,7 +26,7 @@ SPECTOOL := spectool
 # DISTRO_ID (i.e. el7)
 # DISTRO_BASE (i.e. EL_7)
 # from the CHROOT_NAME
-ifeq ($(CHROOT_NAME),epel-7-x86_64)
+ifeq ($(patsubst %epel-7-x86_64,,$(lastword $(subst +, ,$(CHROOT_NAME)))),)
 DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID      := 7
 DISTRO_ID       := el7
@@ -35,7 +35,7 @@ DISTRO_VERSION  ?= $(VERSION_ID)
 ORIG_TARGET_VER := 7
 SED_EXPR        := 1s/$(DIST)//p
 endif
-ifeq ($(CHROOT_NAME),epel-8-x86_64)
+ifeq ($(patsubst %epel-8-x86_64,,$(lastword $(subst +, ,$(CHROOT_NAME)))),)
 DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID      := 8
 DISTRO_ID       := el8
@@ -62,6 +62,18 @@ SED_EXPR        := 1p
 endif
 endif
 ifeq ($(ID),centos)
+ID = el
+endif
+ifeq ($(ID),rocky)
+ID = el
+endif
+ifeq ($(ID),almalinux)
+ID = el
+endif
+ifeq ($(ID),rhel)
+ID = el
+endif
+ifeq ($(ID),el)
 DISTRO_ID := el$(VERSION_ID)
 DISTRO_BASE := $(basename EL_$(VERSION_ID))
 DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -10,7 +10,7 @@ SHELL=/bin/bash
 -include Makefile.local
 
 # default to Leap 15 distro for chrootbuild
-CHROOT_NAME ?= opensuse-leap-15.2-x86_64
+CHROOT_NAME ?= opensuse-leap-15.3-x86_64
 include packaging/Makefile_distro_vars.mk
 
 ifeq ($(DEB_NAME),)
@@ -86,7 +86,7 @@ define distro_map
 	case $(DISTRO_ID) in               \
 	    el7) distro="centos7"          \
 	    ;;                             \
-	    el8) distro="centos8"          \
+	    el8) distro="el8"              \
 	    ;;                             \
 	    sle12.3) distro="sles12.3"     \
 	    ;;                             \
@@ -354,7 +354,7 @@ ifeq ($(LOCAL_REPOS),true)
       endif # ifeq ($(ID_LIKE),debian)
       ifeq ($(DISTRO_BASE), EL_8)
         # hack to use 8.3 non-group repos on EL_8
-        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-8.3-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-8.3-extras-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-8-x86_64-proxy)
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/rocky-8.5-base-x86_64-proxy|$(REPOSITORY_URL)repository/rocky-8.5-extras-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-8-x86_64-proxy)
       else ifeq ($(DISTRO_BASE), EL_7)
         # hack to use 7.9 non-group repos on EL_7
         $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-7.9-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-extras-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-updates-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-7-x86_64-proxy)
@@ -367,11 +367,11 @@ ifeq ($(LOCAL_REPOS),true)
       endif # ifeq ($(DISTRO_BASE), *)
     endif #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
     ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
-      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst centos-8.3,rocky-8.5,$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO))
     endif
     # group repos are not working in Nexus so we hack in the group members directly above
     ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
-      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst centos-8.3,rocky-8.5,$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO))
     endif
     ifneq ($(ID_LIKE),debian)
       ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
@@ -455,6 +455,12 @@ test:
 	# Test the rpmbuild by installing the built RPM
 	$(call install_repos,$(REPO_NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
 	dnf -y install $(TEST_PACKAGES)
+
+show_DISTRO_ID:
+	@echo '$(DISTRO_ID)'
+
+show_distro_map:
+	@$(call distro_map) echo "$$distro"
 
 show_spec:
 	@echo '$(SPEC)'


### PR DESCRIPTION
Define version correctly based on whether or not upstream includes
a patch number. Also pull some dirty tricks on SUSE because SUSE.

Update Jenkinsfile/CODEOWNERS as per pipeline requirements.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>